### PR TITLE
Make memcached user configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ memcached_memory_cap: '64'
 memcached_port: '11211'
 memcached_verbose: false
 memcached_verbose_verbose: false
+memcached_user: memcache

--- a/templates/etc/memcached.conf.j2
+++ b/templates/etc/memcached.conf.j2
@@ -8,6 +8,6 @@ logfile {{ memcached_log_file }}
 {% endif %}
 -m {{ memcached_memory_cap }}
 -p {{ memcached_port }}
--u memcache
+-u {{ memcached_user }}
 -l {{ memcached_listen_address }}
 -c {{ memcached_connections_in_limit }}


### PR DESCRIPTION
The user for memcached by default in CentOS is `memcached` instead of `memcache`. It is
reasonable to make that configuable.